### PR TITLE
Disable manual configuration of the bluetooth interface

### DIFF
--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -1116,14 +1116,6 @@ void initializationStateProcessor() {
         return;
     }
 
-    //
-    // Find the adapter interface
-    //
-    if (!bAdapterConfigured) {
-        Logger::debug(SSTR << "Configuring BlueZ adapter '" << bluezGattManagerInterfaceName << "'");
-        configureAdapter();
-        return;
-    }
 
     //
     // Register our object with D-bus


### PR DESCRIPTION
Disabling ggk configuration of the bluetooth module so the normal bluez DBus can be used from the normal application. This is needed to allow the speaker to be supported. This is also the first step in a fairly easy path forward to drop ggk entirely and use the dbus interface directly from the app. 